### PR TITLE
Bump packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://opensource.org/licenses/apache2.0.php"
   },
   "dependencies": {
-    "@google-cloud/datastore": "^10.0.1",
+    "@google-cloud/datastore": "^9.2.1",
     "child_process": "^1.0.2",
     "colors": "^1.4.0",
     "commander": "^14.0.0",


### PR DESCRIPTION
### Fixes
Downgrade google-cloud/datastore as 10.0.1 depends on vulnerable version of protobufjs
https://app.asana.com/1/27145998307022/project/183329416800305/task/1210233312389134

### Change implications
 - includes or requires infrastructure changes? (tag `'infra-change'`)
