### PR TITLE
Potential fix for code scanning alert no. 2: Indirect uncontrolled command line

### DIFF
--- a/lib/datastore-backup.js
+++ b/lib/datastore-backup.js
@@ -8,6 +8,63 @@ require('colors');
 const {Datastore} = require('@google-cloud/datastore');
 
 /**
+ * Execute a gcloud command safely without invoking a shell.
+ *
+ * @param {string[]} args
+ * @returns {string} stdout as UTF-8 string
+ */
+const execGcloud = (args) => {
+  const result = child_process.spawnSync('gcloud', args, { encoding: 'utf8' });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr || '';
+    const stdout = result.stdout || '';
+    throw new Error(`gcloud ${args.join(' ')} failed with code ${result.status}: ${stderr || stdout}`);
+  }
+  return result.stdout || '';
+};
+
+/**
+ * Build argument list for gcloud datastore import.
+ *
+ * @param {string[]} kinds
+ * @param {string} project
+ * @param {string} bucket
+ * @param {string} timestamp
+ * @param {object} options
+ * @returns {string[]}
+ */
+const buildDatastoreRestoreArgs = (kinds, project, bucket, timestamp, options) => {
+  const args = ['datastore', 'import', '--project', project];
+  if (options && !_.isUndefined(options.account)) {
+    args.push('--account', options.account);
+  }
+  const kindsValue = kinds.join(',');
+  args.push('--kinds', kindsValue);
+  args.push('--async');
+  const backupMetadataFile = 'gs://' + bucket + '/' + timestamp + '/' + timestamp + '.overall_export_metadata';
+  args.push(backupMetadataFile);
+  return args;
+};
+
+/**
+ * Build argument list for gcloud datastore operations list.
+ *
+ * @param {string} project
+ * @param {object} options
+ * @returns {string[]}
+ */
+const buildDatastoreStatusArgs = (project, options) => {
+  const args = ['datastore', 'operations', 'list', '--project', project];
+  if (options && options.account) {
+    args.push('--account', options.account);
+  }
+  return args;
+};
+
+/**
  * create a backup of kinds from project into bucket; depends only on Datastore API client, rather
  * than calling anything on cmd line - so could be run in NodeJS env that can't call out to OS
  * (eg, Cloud Functions or something)
@@ -45,27 +102,44 @@ const backup = async (kinds, project, bucket, options) => {
  * @returns {string} output from the commands
  */
 const testRestoreFromBackup = (kind, project, bucket, timestamp, options) => {
-  let restore = child_process.execSync(datastoreRestoreCommand([kind], project, bucket, timestamp, options)).toString('utf8');
-  let status = child_process.execSync(datastoreStatusCommand(project, options));
+  const restoreArgs = buildDatastoreRestoreArgs([kind], project, bucket, timestamp, options || {});
+  const restore = execGcloud(restoreArgs);
+  const statusArgs = buildDatastoreStatusArgs(project, options || {});
+  const status = execGcloud(statusArgs);
   return restore + "\n" + status;
 };
 
+/**
+ * Build a printable gcloud datastore import command string.
+ *
+ * This is intended for display to the user (for example, in index.js),
+ * not for execution via a shell.
+ *
+ * @param {string[]} kinds
+ * @param {string} project
+ * @param {string} bucket
+ * @param {string} timestamp
+ * @param {object} options
+ * @returns {string}
+ */
 const datastoreRestoreCommand = (kinds, project, bucket, timestamp, options) => {
-  let authOptions = ' --project ' + project;
-  if (!_.isUndefined(options.account)) {
-    authOptions += '--account ' + options.account;
-  }
-  let backupMetadataFile = 'gs://' + bucket + '/' + timestamp + '/' + timestamp + '.overall_export_metadata'
-  return 'gcloud datastore import ' + authOptions + ' --kinds="' + kinds.join(',') + '" --async ' + backupMetadataFile ;
+  const args = buildDatastoreRestoreArgs(kinds, project, bucket, timestamp, options || {});
+  return 'gcloud ' + args.map(String).join(' ');
 };
 
+/**
+ * Build a printable gcloud datastore operations list command string.
+ *
+ * This is intended for display to the user (for example, in index.js),
+ * not for execution via a shell.
+ *
+ * @param {string} project
+ * @param {object} options
+ * @returns {string}
+ */
 const datastoreStatusCommand = (project, options) => {
-  let authOptions = '';
-  if (options.account) {
-    authOptions += ' --account \' + options.account';
-  }
-  authOptions += ' --project ' + project;
-  return 'gcloud datastore operations' + authOptions + ' list';
+  const args = buildDatastoreStatusArgs(project, options || {});
+  return 'gcloud ' + args.map(String).join(' ');
 };
 
 module.exports.backup = backup;


### PR DESCRIPTION
Potential fix for [https://github.com/Worklytics/datastore-backup/security/code-scanning/2](https://github.com/Worklytics/datastore-backup/security/code-scanning/2)

In general, to fix this kind of issue you should avoid passing a single concatenated string to `child_process.exec/execSync` when it includes untrusted data. Instead, use `spawn`/`spawnSync`/`execFile`/`execFileSync` with an array of arguments. This prevents the shell from interpreting metacharacters and removes the need to manually escape arguments.

For this specific code:

* Replace `child_process.execSync(datastoreRestoreCommand(...))` with a safe helper that:
  * Builds an array of arguments for `gcloud`.
  * Calls `child_process.spawnSync('gcloud', args, { encoding: 'utf8' })` (or similar).
  * Throws or logs an error if the command fails.
* Change `datastoreRestoreCommand` and `datastoreStatusCommand` from returning shell command strings to returning arrays of arguments (or small objects containing `{cmd, args}`) that can be passed directly to `spawnSync` / printed out for the user.
* In `index.js`, where these helpers are used just for printing example commands (`restore` action, status monitoring lines), reconstruct printable command strings by joining the safe arg arrays with spaces, rather than using the old string-building helpers.

Concretely, in `lib/datastore-backup.js`:

1. Add small helpers:
   * `buildDatastoreRestoreArgs(kinds, project, bucket, timestamp, options)` → returns an array like:
     `['datastore', 'import', '--project', project, '--kinds', 'Kind1,Kind2', '--async', backupMetadataFile, ...(account args)]`.
   * `buildDatastoreStatusArgs(project, options)` → returns:
     `['datastore', 'operations', 'list', '--project', project, ...(account args)]`.
   * `execGcloud(args)` → calls `spawnSync('gcloud', args, { encoding: 'utf8' })` and returns `stdout` (or throws on error).
2. Update `testRestoreFromBackup` to:
   * Call `execGcloud(buildDatastoreRestoreArgs(...))`.
   * Call `execGcloud(buildDatastoreStatusArgs(...))`.
3. Change `datastoreRestoreCommand` and `datastoreStatusCommand` to be string-formatting wrappers around the arg builders, for use in `index.js` where the user sees and copies commands. They should no longer be used with `execSync`.

In `index.js`:

* Leave the high-level logic intact but rely on the updated `datastoreRestoreCommand`/`datastoreStatusCommand` that return full, ready-to-run `gcloud` commands as strings. This keeps the CLI output behavior unchanged.
* No change is needed for the `backup` flow using the Datastore client library; that doesn’t use shell commands.
* The `list` command still uses `execSync('gsutil ls ' + bucketPrefix ...)`, which is a similar pattern but not currently in the flagged path. Since we are constrained to address the provided alert and its path, and changing that might be considered functional behavior, we will not modify it here.

This preserves functionality (the commands and printed examples remain the same) while ensuring the actually executed `gcloud` commands are invoked without a shell, eliminating the indirect command line injection risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
